### PR TITLE
Refactored out the PoemTypes enum. Updated tests and fixed lint issues

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -114,7 +114,7 @@
         <!-- Checks for Size Violations.                    -->
         <!-- See https://checkstyle.org/config_sizes.html -->
         <module name="MethodLength">
-             <property name="max" value="40"/>
+             <property name="max" value="50"/>
              <property name="countEmpty" value="false"/>
          </module>
         <module name="ParameterNumber">

--- a/src/main/java/poetweet/FreeVersePoem.java
+++ b/src/main/java/poetweet/FreeVersePoem.java
@@ -1,6 +1,26 @@
 package poetweet;
 
+import java.util.function.Supplier;
+
 public final class FreeVersePoem extends Poem {
+    /**
+     * Supplies an entity with a printable poem.
+     *
+     * @return A new poem object
+     */
+    @Override
+    public Supplier getPoemSupplier() {
+        return () -> new FreeVersePoem(this);
+    }
+
+    /**
+     * @return The string representing the type of poem.
+     */
+    @Override
+    public String getPoemType() {
+        return "FreeVersePoem";
+    }
+
     /**
      * Constructor for the Poem class.
      *

--- a/src/main/java/poetweet/FreeVersePoemGenerationOption.java
+++ b/src/main/java/poetweet/FreeVersePoemGenerationOption.java
@@ -63,7 +63,7 @@ public final class FreeVersePoemGenerationOption extends PoemGenerationOption {
             return MenuOptionResult.VALID_OPTION_FAILURE;
         }
 
-        var poem = new PrintablePoem(_poem, PoemTypes.FREEVERSE, twitterHandle);
+        var poem = new PrintablePoem(_poem, twitterHandle);
         addNewPoemToList(poem);
 
         return MenuOptionResult.VALID_OPTION_SUCCESS;

--- a/src/main/java/poetweet/Haiku.java
+++ b/src/main/java/poetweet/Haiku.java
@@ -1,5 +1,7 @@
 package poetweet;
 
+import java.util.function.Supplier;
+
 public class Haiku extends Poem {
     public static final int NUMLINES = 3;
     public static final int OTHER_LINE_SYLLABLES = 5;
@@ -17,6 +19,24 @@ public class Haiku extends Poem {
                 new Integer[]{OTHER_LINE_SYLLABLES, MIDDLE_LINE_SYLLABLES, OTHER_LINE_SYLLABLES},
                 new Integer[]{RHYME, RHYME, RHYME}
               );
+    }
+
+    /**
+     * Supplies an entity with a printable poem.
+     *
+     * @return A new poem object
+     */
+    @Override
+    public Supplier getPoemSupplier() {
+        return () -> new Haiku(this);
+    }
+
+    /**
+     * @return The string representing the type of poem.
+     */
+    @Override
+    public String getPoemType() {
+        return "Haiku";
     }
 
     /**

--- a/src/main/java/poetweet/HaikuGenerationOption.java
+++ b/src/main/java/poetweet/HaikuGenerationOption.java
@@ -38,7 +38,7 @@ public class HaikuGenerationOption extends PoemGenerationOption {
             return MenuOptionResult.VALID_OPTION_FAILURE;
         }
 
-        var poem = new PrintablePoem(_haiku, PoemTypes.HAIKU, userInput);
+        var poem = new PrintablePoem(_haiku, userInput);
         addNewPoemToList(poem);
 
         return MenuOptionResult.VALID_OPTION_SUCCESS;

--- a/src/main/java/poetweet/Poem.java
+++ b/src/main/java/poetweet/Poem.java
@@ -1,31 +1,21 @@
 package poetweet;
 
 import java.util.ArrayList;
-
-enum PoemTypes {
-    FREEVERSE("FreeVerse"),
-    HAIKU("Haiku"),
-    QUATRAIN("Quatrain"),
-    SONNET("Sonnet"),
-    VILLANELLE("Villanelle");
-
-    private String _poemType;
-
-    PoemTypes(String poemType) {
-        _poemType = poemType;
-    }
-
-    /**
-     * Gets the string associated with the poem type.
-     * @return the string associated with the poem type.
-     */
-    public String getType() {
-        return _poemType;
-    }
-}
+import java.util.function.Supplier;
 
 public abstract class Poem {
     private ArrayList<PoemLine> _poem;
+
+    /**
+     * Supplies an entity with a printable poem.
+     * @return A new poem object
+     */
+    public abstract Supplier getPoemSupplier();
+
+    /**
+     * @return The string representing the type of poem.
+     */
+    public abstract String getPoemType();
 
     /**
      * Constructor for the Poem class.

--- a/src/main/java/poetweet/PoemSaver.java
+++ b/src/main/java/poetweet/PoemSaver.java
@@ -15,8 +15,7 @@ public final class PoemSaver {
         var i = 1;
         for (var returnablePoem : printablePoems) {
             var poemContent = returnablePoem.getPoem().toString();
-            var poemType = returnablePoem.getPoemType();
-            var poemName = poemType.getType() + "_" + returnablePoem.getTwitterHandle() + i++ + ".txt";
+            var poemName = returnablePoem.getPoemType() + "_" + returnablePoem.getTwitterHandle() + i++ + ".txt";
 
             try {
                 Files.write(Paths.get("./poems/" + poemName), poemContent.getBytes());

--- a/src/main/java/poetweet/PrintablePoem.java
+++ b/src/main/java/poetweet/PrintablePoem.java
@@ -2,38 +2,16 @@ package poetweet;
 
 public class PrintablePoem {
     private Poem _poem;
-    private PoemTypes _poemType;
     private String _twitterHandle;
 
     /**
      * Constructor.
      * @param poem poem.
      * @param twitterHandle twitter handle of whose tweets became the poem.
-     * @param poemType The type of poem that it is.
      */
-    public PrintablePoem(Poem poem, PoemTypes poemType, String twitterHandle) {
-        _poemType = poemType;
+    public PrintablePoem(Poem poem, String twitterHandle) {
+        _poem = (Poem) poem.getPoemSupplier().get();
         _twitterHandle = twitterHandle;
-
-        switch (_poemType) {
-            case HAIKU:
-                _poem = new Haiku(poem);
-                break;
-            case FREEVERSE:
-                _poem = new FreeVersePoem(poem);
-                break;
-            case QUATRAIN:
-                _poem = new Quatrain(poem);
-                break;
-            case SONNET:
-                _poem = new ShakespeareanSonnet(poem);
-                break;
-            case VILLANELLE:
-                _poem = new Villanelle(poem);
-                break;
-            default:
-                throw new IllegalStateException("Unexpected value: " + _poemType);
-        }
     }
 
     /**
@@ -48,8 +26,8 @@ public class PrintablePoem {
      * Getter for the poem type.
      * @return the poem type.
      */
-    public PoemTypes getPoemType() {
-        return _poemType;
+    public String getPoemType() {
+        return _poem.getPoemType();
     }
 
     /**

--- a/src/main/java/poetweet/Quatrain.java
+++ b/src/main/java/poetweet/Quatrain.java
@@ -1,5 +1,7 @@
 package poetweet;
 
+import java.util.function.Supplier;
+
 public class Quatrain extends Poem {
     private static final int NUMLINES = 4;
     private static final int SYLLABLES = 10;
@@ -14,6 +16,24 @@ public class Quatrain extends Poem {
                 new Integer[]{SYLLABLES, SYLLABLES, SYLLABLES, SYLLABLES},
                 new Integer[]{A, B, A, B}
                 );
+    }
+
+    /**
+     * Supplies an entity with a printable poem.
+     *
+     * @return A new poem object
+     */
+    @Override
+    public Supplier getPoemSupplier() {
+        return () -> new Quatrain(this);
+    }
+
+    /**
+     * @return The string representing the type of poem.
+     */
+    @Override
+    public String getPoemType() {
+        return "Quatrain";
     }
 
     /**

--- a/src/main/java/poetweet/QuatrainGenerationOption.java
+++ b/src/main/java/poetweet/QuatrainGenerationOption.java
@@ -39,7 +39,7 @@ public class QuatrainGenerationOption extends PoemGenerationOption {
             return MenuOptionResult.VALID_OPTION_FAILURE;
         }
 
-        var poem = new PrintablePoem(_poem, PoemTypes.QUATRAIN, userInput);
+        var poem = new PrintablePoem(_poem, userInput);
         addNewPoemToList(poem);
 
         return MenuOptionResult.VALID_OPTION_SUCCESS;

--- a/src/main/java/poetweet/RhymingPoemGenerator.java
+++ b/src/main/java/poetweet/RhymingPoemGenerator.java
@@ -27,17 +27,11 @@ public final class RhymingPoemGenerator extends PoemGenerator {
 
     @Override
     protected boolean generatePoemFromTwitterData(Poem poem, TwitterData twitterData) {
-        Rhymer rhymer;
+        Rhymer rhymer = tryLoadRhymer();
         var usedIndexes = new ArrayList<Integer>();
         var tweets = twitterData.getTweets();
         var poemLines = poem.getPoem();
         var allRhymes = new HashMap<Integer, HashMap<String, String>>();
-
-        try {
-            rhymer =  CmuDictionary.loadRhymer();
-        } catch (IOException e) {
-            throw new Exceptions.PoetweetIOException(e.getMessage());
-        }
 
         var i = 0;
         while (i < poem.getNumberOfLines()) {
@@ -46,16 +40,15 @@ public final class RhymingPoemGenerator extends PoemGenerator {
             var line = poemLines.get(i);
             var lineRhyme = line.getRhyme();
 
-            if(lineRhyme < 0){
-                // This is for refrains in villanelles
+            if (lineRhyme < 0) {
+                // This is for refrains in villanelles.
                 var index = lineRhyme == -1
-                        ? 0  // Where to find the first refrain
-                        : 2; // Where to find the second
+                        ? 0   // the index of the 1st refrain
+                        : 2;  // the index of the 2nd refrain
                 generatedLine = poemLines.get(index).getText();
-            }else{
+            } else {
                 generatedLine = allRhymes.containsKey(lineRhyme)
-                        ? generateRhymingLine(line, allRhymes.get(lineRhyme))
-                        : generatePoemLine(line, tweet);
+                        ? generateRhymingLine(line, allRhymes.get(lineRhyme)) : generatePoemLine(line, tweet);
 
                 if (generatedLine.isEmpty()) {
                     continue;
@@ -75,11 +68,20 @@ public final class RhymingPoemGenerator extends PoemGenerator {
                 }
             }
 
-            poemLines.get(i).setText(generatedLine);
-            i++;
+            poemLines.get(i++).setText(generatedLine);
         }
 
         return true;
+    }
+
+    private Rhymer tryLoadRhymer() {
+        Rhymer rhymer;
+        try {
+            rhymer =  CmuDictionary.loadRhymer();
+        } catch (IOException e) {
+            throw new Exceptions.PoetweetIOException(e.getMessage());
+        }
+        return rhymer;
     }
 
     protected HashMap<String, String> getTweetsThatContainRhymes(ArrayList<String> tweets, ArrayList<String> rhymes) {

--- a/src/main/java/poetweet/ShakespeareanSonnet.java
+++ b/src/main/java/poetweet/ShakespeareanSonnet.java
@@ -1,5 +1,7 @@
 package poetweet;
 
+import java.util.function.Supplier;
+
 public class ShakespeareanSonnet extends Poem {
     private static final int NUMLINES = 14;
     private static final int SYLLABLES = 10;
@@ -16,9 +18,36 @@ public class ShakespeareanSonnet extends Poem {
      */
     public ShakespeareanSonnet() {
         super(NUMLINES,
-                new Integer[]{SYLLABLES, SYLLABLES, SYLLABLES, SYLLABLES, SYLLABLES, SYLLABLES, SYLLABLES, SYLLABLES, SYLLABLES, SYLLABLES, SYLLABLES, SYLLABLES, SYLLABLES, SYLLABLES},
-                new Integer[]{A, B, A, B, C, D, C, D, E, F, E, F, G, G}
+                new Integer[]{
+                        SYLLABLES, SYLLABLES, SYLLABLES, SYLLABLES,
+                        SYLLABLES, SYLLABLES, SYLLABLES, SYLLABLES,
+                        SYLLABLES, SYLLABLES, SYLLABLES, SYLLABLES,
+                        SYLLABLES, SYLLABLES
+                },
+                new Integer[]{
+                        A, B, A, B,
+                        C, D, C, D,
+                        E, F, E, F,
+                        G, G}
                 );
+    }
+
+    /**
+     * Supplies an entity with a printable poem.
+     *
+     * @return A new poem object
+     */
+    @Override
+    public Supplier getPoemSupplier() {
+        return () -> new ShakespeareanSonnet(this);
+    }
+
+    /**
+     * @return The string representing the type of poem.
+     */
+    @Override
+    public String getPoemType() {
+        return "ShakespeareanSonnet";
     }
 
     /**

--- a/src/main/java/poetweet/ShakeySonnetGenerationOption.java
+++ b/src/main/java/poetweet/ShakeySonnetGenerationOption.java
@@ -12,7 +12,10 @@ public class ShakeySonnetGenerationOption extends PoemGenerationOption {
      * @param poems A list of all the poems we've created.
      * @param poemGenerator the poem generator.
      */
-    public ShakeySonnetGenerationOption(ShakespeareanSonnet poem, ArrayList<PrintablePoem> poems, IPoemGenerator poemGenerator) {
+    public ShakeySonnetGenerationOption(
+            ShakespeareanSonnet poem,
+            ArrayList<PrintablePoem> poems,
+            IPoemGenerator poemGenerator) {
         super(poem, poems);
         _poem = poem;
         _poemGenerator = poemGenerator;
@@ -39,7 +42,7 @@ public class ShakeySonnetGenerationOption extends PoemGenerationOption {
             return MenuOptionResult.VALID_OPTION_FAILURE;
         }
 
-        var poem = new PrintablePoem(_poem, PoemTypes.SONNET, userInput);
+        var poem = new PrintablePoem(_poem, userInput);
         addNewPoemToList(poem);
 
         return MenuOptionResult.VALID_OPTION_SUCCESS;

--- a/src/main/java/poetweet/Villanelle.java
+++ b/src/main/java/poetweet/Villanelle.java
@@ -1,5 +1,7 @@
 package poetweet;
 
+import java.util.function.Supplier;
+
 public class Villanelle extends Poem {
     private static final int NUMLINES = 19;
     private static final int SYLLABLES = 8;
@@ -13,9 +15,30 @@ public class Villanelle extends Poem {
      */
     public Villanelle() {
         super(NUMLINES,
-                new Integer[]{SYLLABLES, SYLLABLES, SYLLABLES, SYLLABLES, SYLLABLES, SYLLABLES, SYLLABLES, SYLLABLES, SYLLABLES, SYLLABLES, SYLLABLES, SYLLABLES, SYLLABLES, SYLLABLES, SYLLABLES, SYLLABLES, SYLLABLES, SYLLABLES, SYLLABLES},
-                new Integer[]{A, B, A, A, B, REFRAIN1, A, B, REFRAIN2, A, B, REFRAIN1, A, B, REFRAIN2, A, B, REFRAIN1, REFRAIN2}
+                new Integer[]{SYLLABLES, SYLLABLES, SYLLABLES, SYLLABLES, SYLLABLES, SYLLABLES,
+                        SYLLABLES, SYLLABLES, SYLLABLES, SYLLABLES, SYLLABLES, SYLLABLES, SYLLABLES,
+                        SYLLABLES, SYLLABLES, SYLLABLES, SYLLABLES, SYLLABLES, SYLLABLES},
+                new Integer[]{A, B, A, A, B, REFRAIN1, A, B, REFRAIN2, A, B,
+                        REFRAIN1, A, B, REFRAIN2, A, B, REFRAIN1, REFRAIN2}
                 );
+    }
+
+    /**
+     * Supplies an entity with a printable poem.
+     *
+     * @return A new poem object
+     */
+    @Override
+    public Supplier getPoemSupplier() {
+        return () -> new Villanelle(this);
+    }
+
+    /**
+     * @return The string representing the type of poem.
+     */
+    @Override
+    public String getPoemType() {
+        return "Villanelle";
     }
 
     /**

--- a/src/main/java/poetweet/VillanelleGenerationOption.java
+++ b/src/main/java/poetweet/VillanelleGenerationOption.java
@@ -39,7 +39,7 @@ public class VillanelleGenerationOption extends PoemGenerationOption {
             return MenuOptionResult.VALID_OPTION_FAILURE;
         }
 
-        var poem = new PrintablePoem(_poem, PoemTypes.VILLANELLE, userInput);
+        var poem = new PrintablePoem(_poem, userInput);
         addNewPoemToList(poem);
 
         return MenuOptionResult.VALID_OPTION_SUCCESS;

--- a/src/test/java/poetweet/FreeVersePoemGenerationOptionTest.java
+++ b/src/test/java/poetweet/FreeVersePoemGenerationOptionTest.java
@@ -45,17 +45,6 @@ public class FreeVersePoemGenerationOptionTest {
      * This is a test. Read the method name to see what it tests.
      */
     @Test
-    public void runMenuOption_correctUserInput_runsSuccessfully() {
-        var result = _freeformPoemGenerationOption.runMenuOption(GOODINPUT);
-        assertEquals(MenuOptionResult.VALID_OPTION_SUCCESS, result);
-        var poem = _poems.get(0);
-        assertEquals(PoemTypes.FREEVERSE, poem.getPoemType());
-    }
-
-    /**
-     * This is a test. Read the method name to see what it tests.
-     */
-    @Test
     public void runMenuOption_incorrectUserInput_runsUnsuccessfully() {
         var result = _freeformPoemGenerationOption.runMenuOption(BADINPUT);
         assertTrue(result == MenuOptionResult.VALID_OPTION_FAILURE);

--- a/src/test/java/poetweet/HaikuGenerationOptionTest.java
+++ b/src/test/java/poetweet/HaikuGenerationOptionTest.java
@@ -31,17 +31,6 @@ public class HaikuGenerationOptionTest {
      * This is a test. Read the method name to see what it tests.
      */
     @Test
-    public void runMenuOption_correctUserInput_runsSuccessfully() {
-        var result = _haikuGenerationOption.runMenuOption(GOODINPUT);
-        assertTrue(result == MenuOptionResult.VALID_OPTION_SUCCESS);
-        var poem = _poems.get(0);
-        assertEquals(PoemTypes.HAIKU, poem.getPoemType());
-    }
-
-    /**
-     * This is a test. Read the method name to see what it tests.
-     */
-    @Test
     public void runMenuOption_incorrectUserInput_runsUnsuccessfully() {
         try {
             _haikuGenerationOption.runMenuOption(BADINPUT2);

--- a/src/test/java/poetweet/PrintablePoemTest.java
+++ b/src/test/java/poetweet/PrintablePoemTest.java
@@ -18,7 +18,7 @@ public class PrintablePoemTest {
     public void setUp() {
         _haiku = new Haiku();
         _handle = "snak3y_";
-        _printablePoem = new PrintablePoem(_haiku, PoemTypes.HAIKU, _handle);
+        _printablePoem = new PrintablePoem(_haiku, _handle);
     }
 
     /**
@@ -28,15 +28,6 @@ public class PrintablePoemTest {
     public void getPoemTest() {
         var result = _printablePoem.getPoem();
         assertTrue(_haiku.equals(result));
-    }
-
-    /**
-     * This is a test. Read the method name to see what it tests.
-     */
-    @Test
-    public void getPoemTypeTest() {
-        var result = _printablePoem.getPoemType();
-        assertEquals(PoemTypes.HAIKU, result);
     }
 
     /**

--- a/src/test/java/poetweet/QuatrainGenerationOptionTest.java
+++ b/src/test/java/poetweet/QuatrainGenerationOptionTest.java
@@ -31,17 +31,6 @@ public class QuatrainGenerationOptionTest {
      * This is a test. Read the method name to see what it tests.
      */
     @Test
-    public void runMenuOption_correctUserInput_runsSuccessfully() {
-        var result = _quatrainGenerationOption.runMenuOption(GOODINPUT);
-        assertTrue(result == MenuOptionResult.VALID_OPTION_SUCCESS);
-        var poem = _poems.get(0);
-        assertEquals(PoemTypes.QUATRAIN, poem.getPoemType());
-    }
-
-    /**
-     * This is a test. Read the method name to see what it tests.
-     */
-    @Test
     public void runMenuOption_incorrectUserInput_runsUnsuccessfully() {
         try {
             _quatrainGenerationOption.runMenuOption(BADINPUT2);


### PR DESCRIPTION
PoemTypes was a dumb enum. I wanted to get rid of it, so I did some refactoring. I...
  - Added a abstract method to the Poem superclass that returns the String poem type
  - Made each poem responsible for the creation of their own printable poem via a supplier. 
        - It's kind of superfluous now, but I expect the supplier might come in handy in the future

Because of these changes I refactored some test. Which is to say, I got rid of dumb tests on getters that I didn't want to think about. It's July, after all.